### PR TITLE
Warn on unknown quest requirements and clear data on shutdown

### DIFF
--- a/src/main/java/com/itemrequirements/ItemRequirementsData.java
+++ b/src/main/java/com/itemrequirements/ItemRequirementsData.java
@@ -64,8 +64,8 @@ public class ItemRequirementsData
                                 }
                                 catch (IllegalArgumentException ignored)
                                 {
-                                    // Unknown quest string; ignore it, but leave a debug trace for devs
-                                    log.debug("Ignoring unknown quest requirement string: {}", text);
+                                    // Unknown quest string; warn during development so it can be fixed
+                                    log.warn("Ignoring unknown quest requirement string: {}", text);
                                 }
                             }
                             continue;
@@ -107,6 +107,15 @@ public class ItemRequirementsData
     public static void reloadRequirements(Gson gson)
     {
         loadFromJson(gson);
+    }
+
+    /**
+     * Clears all loaded item requirements.
+     */
+    public static void clear()
+    {
+        ITEM_REQUIREMENTS.clear();
+        ITEM_REQUIREMENTS_BY_ID.clear();
     }
 
 }

--- a/src/main/java/com/itemrequirements/ItemRequirementsPlugin.java
+++ b/src/main/java/com/itemrequirements/ItemRequirementsPlugin.java
@@ -45,12 +45,13 @@ public class ItemRequirementsPlugin extends Plugin
 	}
 
 	@Override
-	protected void shutDown() throws Exception
-	{
-		log.info("Item Requirements stopped!");
-		overlayManager.remove(overlay);
-		overlayManager.remove(tooltipOverlay);
-	}
+        protected void shutDown() throws Exception
+        {
+                log.info("Item Requirements stopped!");
+                overlayManager.remove(overlay);
+                overlayManager.remove(tooltipOverlay);
+                ItemRequirementsData.clear();
+        }
 
 	public void reloadRequirements()
 	{


### PR DESCRIPTION
## Summary
- Warn when quest requirement strings don't match known enums
- Clear cached item requirements when the plugin shuts down

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies junit:junit:4.12, net.runelite:jshell due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68acbd3699dc832d88aece365d4a7a84